### PR TITLE
set schedulerName for advanced example

### DIFF
--- a/examples/advanced/tidb-cluster.yaml
+++ b/examples/advanced/tidb-cluster.yaml
@@ -112,7 +112,7 @@ spec:
   ## SchedulerName of TiDB cluster pods.
   ## If specified, the pods will be scheduled by the specified scheduler.
   ## Can be overwritten by component settings.
-  # schedulerName: tidb-scheduler
+  schedulerName: tidb-scheduler
 
   ## Affinity for pod scheduling, will be overwritten by each cluster component's specific affinity setting
   ## Can refer to PD/TiDB/TiKV affinity settings, and ensure only cluster-scope general settings here


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB Operator!
Please complete the following template before creating a PR.
Ref: TiDB Operator [CONTRIBUTING](https://github.com/pingcap/tidb-operator/blob/master/CONTRIBUTING.md) document
-->

### What problem does this PR solve?

[in the doc](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/configure-a-tidb-cluster#%E9%AB%98%E5%8F%AF%E7%94%A8%E9%85%8D%E7%BD%AE), we said `目前，TiDB 集群使用该调度器作为默认调度器`, so it's better to set `spec.schedulerName` for our advanced example.

### What is changed and how does it work?

### Code changes

- [ ] Has Go code change
- [ ] Has CI related scripts change

### Tests
<!-- AT LEAST ONE test must be included. -->

- [ ] Unit test <!-- If you added any unit test cases, check this box -->
- [ ] E2E test <!-- If you added any e2e test cases, check this box -->
- [ ] Manual test <!-- If this PR needs manual test, check this box, and add detailed manual test scripts or steps below, so that ANYONE CAN REPRODUCE IT. Ref: https://github.com/pingcap/tidb-operator/pull/3517 -->
- [x] No code <!-- If this PR contains no code changes, check this box -->

### Side effects

- [ ] Breaking backward compatibility <!-- If this PR breaks things deployed with previous TiDB Operator versions, check this box -->
- [ ] Other side effects: <!-- Any other side effects, such as requiring additional storage / consumes substantial memory / potential reconciliation latency -->

### Related changes

- [x] Need to cherry-pick to the release branch <!-- If this PR should also appear in the current release branch, check this box -->
- [ ] Need to update the documentation <!-- If this PR introduces new features or changes previous usages, check this box -->

### Release Notes
<!--
If no need to add a release note, just type `NONE` in the following `release-note` block.
If the PR requires additional action from users to deploy the new release, start the release note with "ACTION REQUIRED: ".
-->
Please refer to [Release Notes Language Style Guide](https://github.com/pingcap/tidb-operator/blob/master/docs/release-note-guide.md) before writing the release note.

```release-note
None
```
